### PR TITLE
Fix cp errors with pax/chflags

### DIFF
--- a/etc/rc.d/dsbd_lab_board
+++ b/etc/rc.d/dsbd_lab_board
@@ -86,6 +86,8 @@ fetch_library() {
             tar xkf - -C "/tmp/pot/${latest_release}/lib64cb/"
         fi
     fi
+
+    chflags -R noschg "/tmp/pot/${latest_release}"
 }
 
 generate_pair() {
@@ -107,11 +109,10 @@ generate_pair() {
                 -f "${latest_flavour}" \
                 -t single || exit 1
             pot start -p "${safe_release}"
-            pot exec -p "${safe_release}" cp -R /root/lib64/usr/ /usr
-            if [ "${latest_release##*"22."*}" ]; then
-                pot exec -p "${safe_release}" cp -R /root/lib64cb/usr/ /usr
-            fi
-            pot exec -p "${safe_release}" rm -rdf /root/usr/
+            pot exec -p "${safe_release}" cd /root/
+            pot exec -p "${safe_release}" pax -rw . /usr/
+            pot exec -p "${safe_release}" rm -rdf /root/lib64
+            pot exec -p "${safe_release}" rm -rdf /root/lib64cb
             pot stop -p "${safe_release}"
             pot snap -p "${safe_release}"
         fi

--- a/etc/rc.d/dsbd_lab_board
+++ b/etc/rc.d/dsbd_lab_board
@@ -19,7 +19,7 @@ configure_env() {
     export HOME=/root
     export HOST_ID="${HOST_ID:-0}"
     export RUNNER_PREFIX="${RUNNER_PREFIX:-dsbd-remote-lab}"
-    export RC_VERSION="${RC_VERSION:-1.0.0}"
+    export RC_VERSION="${RC_VERSION:-1.0.1}"
 }
 
 configure_zfs() {

--- a/usr/local64/etc/pot/flavours/arm64-aarch64c-22_05
+++ b/usr/local64/etc/pot/flavours/arm64-aarch64c-22_05
@@ -1,4 +1,4 @@
-copy-in -s /tmp/pot/22.05/lib64/ -d /root/lib64
+copy-in -s /tmp/pot/22.05/lib64/usr/lib64 -d /root/lib64
 set-attribute -A no-tmpfs -V ON
 set-attribute -A nullfs -V ON
 set-attribute -A zfs -V ON

--- a/usr/local64/etc/pot/flavours/arm64-aarch64c-22_05p1
+++ b/usr/local64/etc/pot/flavours/arm64-aarch64c-22_05p1
@@ -1,4 +1,4 @@
-copy-in -s /tmp/pot/22.05p1/lib64/ -d /root/lib64
+copy-in -s /tmp/pot/22.05p1/lib64/usr/lib64 -d /root/lib64
 set-attribute -A no-tmpfs -V ON
 set-attribute -A nullfs -V ON
 set-attribute -A zfs -V ON

--- a/usr/local64/etc/pot/flavours/arm64-aarch64c-22_12
+++ b/usr/local64/etc/pot/flavours/arm64-aarch64c-22_12
@@ -1,4 +1,4 @@
-copy-in -s /tmp/pot/22.12/lib64/ -d /root/lib64
+copy-in -s /tmp/pot/22.12/lib64/usr/lib64 -d /root/lib64
 set-attribute -A no-tmpfs -V ON
 set-attribute -A nullfs -V ON
 set-attribute -A zfs -V ON

--- a/usr/local64/etc/pot/flavours/arm64-aarch64c-23_11
+++ b/usr/local64/etc/pot/flavours/arm64-aarch64c-23_11
@@ -1,5 +1,5 @@
-copy-in -s /tmp/pot/23.11/lib64/ -d /root/lib64
-copy-in -s /tmp/pot/23.11/lib64cb -d /root/lib64cb
+copy-in -s /tmp/pot/23.11/lib64/usr/lib64 -d /root/lib64
+copy-in -s /tmp/pot/23.11/lib64cb/usr/lib64cb -d /root/lib64cb
 set-attribute -A no-tmpfs -V ON
 set-attribute -A nullfs -V ON
 set-attribute -A zfs -V ON

--- a/usr/local64/etc/pot/flavours/arm64-aarch64c-24_05
+++ b/usr/local64/etc/pot/flavours/arm64-aarch64c-24_05
@@ -1,5 +1,5 @@
-copy-in -s /tmp/pot/24.05/lib64/ -d /root/lib64
-copy-in -s /tmp/pot/24.05/lib64cb -d /root/lib64cb
+copy-in -s /tmp/pot/24.05/lib64/usr/lib64 -d /root/lib64
+copy-in -s /tmp/pot/24.05/lib64cb/usr/lib64cb -d /root/lib64cb
 set-attribute -A no-tmpfs -V ON
 set-attribute -A nullfs -V ON
 set-attribute -A zfs -V ON


### PR DESCRIPTION
Pot itself uses `/bin/cp` to copy files into a jail. This command will likely fail when it encounters the schg (immutable) flag on any C shared objects, of which there are a few in the CheriBSD tarballs lib64.txz and lib64cb.txz. There are alternatives, such as `pax`, which seem to handle it more effectively.

In the event that Pot's `copy-in` fails, it's common to have to apply `chflags` manually on the host and copy the files from a temporary location in the jail to its own `/usr` directory.

Regardless, both package managers (pkg64/pkg64cb) must be able to bootstrap afterwards.