### PR TITLE
Add CHERI RISC-V flavours

### DIFF
--- a/usr/local64/etc/pot/flavours/riscv-riscv64c-22_05
+++ b/usr/local64/etc/pot/flavours/riscv-riscv64c-22_05
@@ -1,0 +1,4 @@
+copy-in -s /tmp/pot/22.05/lib64/usr/lib64 -d /root/lib64
+set-attribute -A no-tmpfs -V ON
+set-attribute -A nullfs -V ON
+set-attribute -A zfs -V ON

--- a/usr/local64/etc/pot/flavours/riscv-riscv64c-22_05p1
+++ b/usr/local64/etc/pot/flavours/riscv-riscv64c-22_05p1
@@ -1,0 +1,4 @@
+copy-in -s /tmp/pot/22.05p1/lib64/usr/lib64 -d /root/lib64
+set-attribute -A no-tmpfs -V ON
+set-attribute -A nullfs -V ON
+set-attribute -A zfs -V ON

--- a/usr/local64/etc/pot/flavours/riscv-riscv64c-22_12
+++ b/usr/local64/etc/pot/flavours/riscv-riscv64c-22_12
@@ -1,0 +1,4 @@
+copy-in -s /tmp/pot/22.12/lib64/usr/lib64 -d /root/lib64
+set-attribute -A no-tmpfs -V ON
+set-attribute -A nullfs -V ON
+set-attribute -A zfs -V ON

--- a/usr/local64/etc/pot/flavours/riscv-riscv64c-23_11
+++ b/usr/local64/etc/pot/flavours/riscv-riscv64c-23_11
@@ -1,0 +1,4 @@
+copy-in -s /tmp/pot/23.11/lib64/usr/lib64 -d /root/lib64
+set-attribute -A no-tmpfs -V ON
+set-attribute -A nullfs -V ON
+set-attribute -A zfs -V ON

--- a/usr/local64/etc/pot/flavours/riscv-riscv64c-24_05
+++ b/usr/local64/etc/pot/flavours/riscv-riscv64c-24_05
@@ -1,0 +1,4 @@
+copy-in -s /tmp/pot/24.05/lib64/usr/lib64 -d /root/lib64
+set-attribute -A no-tmpfs -V ON
+set-attribute -A nullfs -V ON
+set-attribute -A zfs -V ON


### PR DESCRIPTION
This PR adds the Pot flavours for CheriBSD-based CHERI RISC-V VMs and hardware.