### PR TITLE
Add host interface option

### DIFF
--- a/etc/rc.d/dsbd_lab_board
+++ b/etc/rc.d/dsbd_lab_board
@@ -18,6 +18,7 @@ configure_env() {
     export PATH="$PATH:/usr/local64/bin"
     export HOME=/root
     export HOST_ID="${HOST_ID:-0}"
+    export HOST_INTERFACE="${HOST_INTERFACE:-re0}"
     export RUNNER_PREFIX="${RUNNER_PREFIX:-dsbd-remote-lab}"
     export RC_VERSION="${RC_VERSION:-1.0.2}"
 }
@@ -60,7 +61,7 @@ configure_pot() {
     # Enable the virtual NIC, basic logging, and VNET isolation
     echo "# pot configuration file
 POT_CACHE=/opt/pot/cache
-POT_EXTIF=re0
+POT_EXTIF=$HOST_INTERFACE
 POT_ISOLATE_VNET_POTS=true
 POT_EXTRA_MANIFEST_URL=$base_url/$latest_release/ftp/
 POT_LOG_FACILITY=local2" > /usr/local64/etc/pot/pot.conf


### PR DESCRIPTION
There may be occasions where one or more non-Realtek devices are required, hence the interface name itself ought to be an option.